### PR TITLE
Add release creation to riscv64 build workflow

### DIFF
--- a/.github/workflows/build-riscv64.yml
+++ b/.github/workflows/build-riscv64.yml
@@ -52,3 +52,62 @@ jobs:
       - name: Cleanup
         if: always()
         run: rm -rf /tmp/build-venv /tmp/wheels
+
+  release:
+    needs: build
+    runs-on: [self-hosted, linux, riscv64]
+    if: success()
+    steps:
+      - name: Download wheel artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: wheel-riscv64
+          path: /tmp/wheels/
+
+      - name: Get wheel info
+        id: wheel_info
+        run: |
+          WHL=$(ls /tmp/wheels/*.whl | head -1)
+          BASENAME=$(basename "$WHL")
+          # Extract version from wheel filename: name-version-cpXX-...
+          VERSION=$(echo "$BASENAME" | sed 's/^[^-]*-\([^-]*\)-.*/\1/')
+          echo "whl_path=$WHL" >> "$GITHUB_OUTPUT"
+          echo "whl_name=$BASENAME" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Generate checksums
+        run: |
+          cd /tmp/wheels
+          sha256sum *.whl > SHA256SUMS
+
+      - name: Create or update release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="riscv64-v${{ steps.wheel_info.outputs.version }}"
+          TITLE="riscv64 wheel v${{ steps.wheel_info.outputs.version }}"
+
+          # Delete existing release with same tag if it exists
+          gh release delete "$TAG" --yes 2>/dev/null || true
+          git tag -d "$TAG" 2>/dev/null || true
+          git push origin ":refs/tags/$TAG" 2>/dev/null || true
+
+          # Create new release
+          gh release create "$TAG" \
+            --title "$TITLE" \
+            --notes "Prebuilt riscv64 wheel for $(uname -m) Linux.
+
+          Built on: BananaPi F3 (SpacemiT K1, rv64imafdcv)
+          Python: $(python3 --version 2>&1)
+          Wheel: ${{ steps.wheel_info.outputs.whl_name }}
+
+          Install:
+          \`\`\`
+          pip install tiktoken --find-links https://github.com/gounthar/tiktoken/releases/download/$TAG/
+          \`\`\`" \
+            /tmp/wheels/*.whl \
+            /tmp/wheels/SHA256SUMS
+
+      - name: Cleanup
+        if: always()
+        run: rm -rf /tmp/wheels


### PR DESCRIPTION
## Summary
- After successful wheel build, create a GitHub Release with the .whl file
- Release tagged as `riscv64-vVERSION` with install instructions
- Includes SHA256SUMS for integrity verification
- Enables `pip install --find-links` from release URL