### PR TITLE
fix: set GH_REPO for gh release commands

### DIFF
--- a/.github/workflows/build-riscv64.yml
+++ b/.github/workflows/build-riscv64.yml
@@ -57,6 +57,8 @@ jobs:
     needs: build
     runs-on: [self-hosted, linux, riscv64]
     if: success()
+    env:
+      GH_REPO: ${{ github.repository }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Fix `gh release` commands failing with:

> No default remote repository has been set for this directory.
> please run `gh repo set-default`

The `github-act-runner` (Go-based runner for riscv64) doesn't set
`GITHUB_REPOSITORY` the same way the official runner does, so `gh`
can't auto-detect the repo context.

Fix: add job-level `env.GH_REPO` set to `${{ github.repository }}`
in the `release` job so all `gh` commands know the target repo.