### PR TITLE
fix: install cffi into opt Python before maturin build

### DIFF
--- a/.github/workflows/build-riscv64.yml
+++ b/.github/workflows/build-riscv64.yml
@@ -35,6 +35,11 @@ jobs:
       - name: Build wheel
         run: |
           sudo apt-get update && sudo apt-get install -y libffi-dev
+          # cffi must be installed in every Python maturin auto-discovers for
+          # FFI declaration generation.  uvx --with cffi covers the tool env
+          # (Python 3.14); install it separately into the RISE runner's opt
+          # Python so maturin can generate declarations for that interpreter too.
+          sudo /opt/python-3.12/bin/python3 -m pip install --quiet cffi
           uvx --python 3.14 --with maturin --with setuptools --with cffi maturin build --release --out /tmp/wheels/
 
       - name: Verify platform tag


### PR DESCRIPTION
## Summary

- `uvx --with cffi` installs cffi only in the uvx tool environment (Python 3.14)
- maturin auto-discovers `/opt/python-3.12/bin/python3` from PATH on the RISE runner and uses it to generate cffi FFI declarations
- that Python has no cffi, causing the build to fail with `ModuleNotFoundError: No module named 'cffi'`

Fix: install cffi into `/opt/python-3.12` explicitly before invoking maturin.

Fixes the failure in https://github.com/gounthar/tiktoken/actions/runs/24298872497

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build reliability for riscv64 architecture by ensuring required dependencies are properly available during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->