### PR TITLE
ci: check out riscv64 build source from upstream openai/tiktoken

### DIFF
--- a/.github/workflows/build-riscv64.yml
+++ b/.github/workflows/build-riscv64.yml
@@ -20,7 +20,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.release_tag || github.ref }}
+          repository: openai/tiktoken
+          ref: ${{ inputs.release_tag || 'main' }}
           fetch-depth: 0
 
       - name: Setup Rust


### PR DESCRIPTION
## Problem

Run [25950800792](https://github.com/gounthar/tiktoken/actions/runs/25950800792) failed at `Checkout` with `a branch or tag with the name 'v0.13.0' could not be found`.

Two compounding causes:

1. The build job's checkout had no `repository:` input, so `release_tag` resolved against this fork. The fork's newest tag is `0.12.0`; upstream `openai/tiktoken` published `0.13.0` on 2026-05-15 but the fork never mirrored it.
2. The run was dispatched with `v0.13.0`, but tiktoken tags carry no `v` prefix (upstream tag is `0.13.0`).

## Fix

Pin the build checkout to `repository: openai/tiktoken` and fall back to its `main` branch. The build no longer depends on the fork mirroring upstream tags; dispatching with an upstream release tag works directly. This is the same pattern applied to the pytorch riscv64 build.

## Notes

- Scope limited to the build job checkout. The `release` job still checks out the fork (correct: it pushes the riscv64 tag/release there).
- yamllint reports pre-existing line-length warnings on lines 29/30/39/110 (upstream-authored run blocks), untouched here.
- After merge, re-dispatch with `release_tag: 0.13.0` (no `v` prefix).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the RISC-V 64-bit build workflow to support manual triggering from specific release tags, while scheduled builds continue to use the main branch by default for streamlined release management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gounthar/tiktoken/pull/10?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->